### PR TITLE
Fix source of embed token error

### DIFF
--- a/SalesforceAppOwnsDataEmbedding/force-app/main/default/classes/PowerBiEmbedManager.cls
+++ b/SalesforceAppOwnsDataEmbedding/force-app/main/default/classes/PowerBiEmbedManager.cls
@@ -150,7 +150,7 @@ public with sharing class PowerBiEmbedManager {
             System.debug('ERROR --- Getting Embed Token --- ERROR');
             System.debug('Status Code: ' + responseEmbedToken.getStatusCode());            
             PowerBiReportData getEmbedTokenError = new PowerBiReportData();
-            getEmbedTokenError.error = 'Get Embed Token Error: ' + response.getStatus();
+            getEmbedTokenError.error = 'Get Embed Token Error: ' + responseEmbedToken.getStatus();
             return getEmbedTokenError;            
         }            
 


### PR DESCRIPTION
The embed token error message was being set to the status from the report data API response.
Looks like a copy/paste error.